### PR TITLE
fix: use chunk.fileName as id instead of chunk.facadeModuleId

### DIFF
--- a/src/your-function.js
+++ b/src/your-function.js
@@ -56,7 +56,7 @@ const yourFunction = (settings={}) => {
             return await fnWrap(
                 source,
                 {
-                    id: chunk.facadeModuleId,
+                    id: chunk.fileName,
                     chunk,
                     outputOptions,
                     meta


### PR DESCRIPTION
because dynamic imports should also be wraped in function-call. `facadeModuleId` is only filled for known module names, but `fileName` is filled for known modules and dynamic imports.

Without this change dynamic imports won't be pushed through the function wrap here: https://github.com/UmamiAppearance/rollup-plugin-your-function/blob/main/src/your-function.js#L28